### PR TITLE
Fix broken document links for publishing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ Follow the conventions outlined in [CONTRIBUTING.md](./CONTRIBUTING.md):
 - Follow the established patterns in [src/](./src/) directory
 
 ### Architecture Decisions
-Before making significant changes, review the [Architecture Decision Records (ADRs)](./docs/adrs/README.md). These documents capture important architectural decisions and provide context for current design choices.
+Before making significant changes, review the [Architecture Decision Records (ADRs)](./docs/adrs.md). These documents capture important architectural decisions and provide context for current design choices.
 
 ## File Structure Reference
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ Thank you for your interest in contributing to Canon! This document outlines the
 
 ## Architecture Decision Records (ADRs)
 
-Before making significant changes to the project architecture, please read the existing [Architecture Decision Records (ADRs)](./docs/adrs/README.md). ADRs document important architectural decisions and provide context for why certain choices were made.
+Before making significant changes to the project architecture, please read the existing [Architecture Decision Records (ADRs)](./docs/adrs.md). ADRs document important architectural decisions and provide context for why certain choices were made.
 
 ### Creating New ADRs
 
@@ -96,7 +96,7 @@ When making architectural decisions that affect the project structure, configura
 - **Link ADRs:** `cd docs/adrs && npx adr link <from> <to> <relationship>`
 - **Help:** `cd docs/adrs && npx adr help`
 
-For more details, see the [ADR README](./docs/adrs/README.md).
+For more details, see the [ADR Documentation](./docs/adrs.md).
 
 ### ADR Lifecycle
 

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ This package requires the following peer dependencies:
 Canon maintains transparent planning and strategic direction separate from the published package:
 
 - **Technology Radar**: [docs/planning/radar/](docs/planning/radar/) - Technology recommendations and assessments
-- **Strategic Vision**: [planning/strategy.md](planning/strategy.md) - Long-term direction and positioning
-- **Development Roadmap**: [planning/roadmap.md](planning/roadmap.md) - Detailed development phases and milestones
+- **Strategic Vision**: [docs/planning/](docs/planning/) - Long-term direction and positioning
+- **Development Roadmap**: [docs/planning/](docs/planning/) - Detailed development phases and milestones
 - **Update Radar**: `npm run radar:convert` - Convert YAML to CSV for visualization
 
 ## Development

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -33,7 +33,7 @@ export default {
                 { text: 'User Authentication Tokens', link: '/docs/examples/user-authentication-tokens' }
               ]
             },
-            { text: 'Radar Methodology', link: '/radar-methodology' }
+            { text: 'Radar Methodology', link: '/docs/radar-methodology' }
           ]
         }
       ],
@@ -64,14 +64,12 @@ export default {
           text: 'Planning & Strategy',
           items: [
             { text: 'Overview', link: '/planning/' },
-            { text: 'Strategy', link: '/planning/strategy' },
-            { text: 'Roadmap', link: '/planning/roadmap' },
             {
               text: 'Technology Radar',
               items: [
                 { text: 'Overview', link: '/planning/radar/' },
                 { text: 'Interactive Radar', link: '/planning/radar/radar.html' },
-                { text: 'Methodology', link: '/radar-methodology' }
+                { text: 'Methodology', link: '/docs/radar-methodology' }
               ]
             }
           ]

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ Welcome to the Canon documentation. This directory contains comprehensive guides
 
 - [Canons](./canons.md) - Understanding Canon types and their implementation
 - [Axioms](./axioms.md) - Deep dive into axiomatic primitives and their role in the type system
-- [Core Axioms](./core-axioms.md) - The essential set of axioms that form the foundation of Canon
+- [Reference Axioms](../reference/axioms.md) - The essential set of axioms that form the foundation of Canon
 - [Examples](./examples/) - Comprehensive examples of core axioms in practice
 
 ## Quick Start

--- a/docs/adrs.md
+++ b/docs/adrs.md
@@ -91,7 +91,7 @@ npm install
 
 If adr-tools is not available, you can create ADRs manually:
 
-1. Copy the template from `template.md`
+1. Copy the template from an existing ADR file
 2. Rename it to `XXXX-descriptive-title.md` where XXXX is the next sequential number
 3. Fill in the template with your decision
 4. Use `npm run adr:index` to generate an updated table of contents

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -21,7 +21,7 @@ Architecture Decision Records are documents that capture important architectural
 
 ## ADR Process
 
-For detailed information about creating and managing ADRs, see the [ADR Documentation](../adrs).
+For detailed information about creating and managing ADRs, see the [ADR Documentation](./adrs.md).
 
 ## ADR Status Legend
 

--- a/docs/canons.md
+++ b/docs/canons.md
@@ -322,7 +322,7 @@ idOf(mongoData) // "user-123" using '_id'
 ## Best Practices
 
 1. **Complete Canon Definition**: Always include both type-level and runtime definitions
-2. **Use Core Axioms**: Start with the [core axiom set](./core-axioms.md) before adding custom ones
+2. **Use Core Axioms**: Start with the [core axiom set](../reference/axioms.md) before adding custom ones
 3. **Register Early**: Register canons at application startup for best performance
 4. **Leverage Type Safety**: Use the `Satisfies` constraint to ensure compile-time type checking
 5. **Document Dependencies**: Clearly document inter-canon relationships

--- a/docs/examples/tree-walk-over-mixed-entities.md
+++ b/docs/examples/tree-walk-over-mixed-entities.md
@@ -8,8 +8,8 @@ This document demonstrates a real-world scenario where we need to walk a tree of
 
 For more practical examples of Canon in action, see:
 
-- [Deduplicating Entities](./examples/deduplicating-entities.md) - How to identify and merge duplicate entities across different data sources
-- [User Authentication Tokens](./examples/user-authentication-tokens.md) - Cross-source data transformation for authentication systems
+- [Deduplicating Entities](./deduplicating-entities.md) - How to identify and merge duplicate entities across different data sources
+- [User Authentication Tokens](./user-authentication-tokens.md) - Cross-source data transformation for authentication systems
 
 ## The Scenario
 

--- a/docs/planning/index.md
+++ b/docs/planning/index.md
@@ -4,12 +4,6 @@ This section contains strategic planning and direction for the Canon project, se
 
 ## Contents
 
-### [Strategy](./strategy)
-Strategic vision, positioning, and long-term direction for Canon as the foundational library for the TypeScript type ecosystem.
-
-### [Roadmap](./roadmap)
-Detailed development roadmap with phases, milestones, and success criteria for Canon's evolution over the next 12+ months.
-
 ### [Technology Radar](./radar/)
 Our comprehensive technology radar tracking recommendations for tools, techniques, features, and data formats used with Canon.
 

--- a/docs/radar-methodology.md
+++ b/docs/radar-methodology.md
@@ -205,5 +205,5 @@ Each major radar decision should be documented as an ADR, including:
 
 - [ThoughtWorks Technology Radar](https://www.thoughtworks.com/radar)
 - [Build Your Own Radar](https://github.com/thoughtworks/build-your-own-radar)
-- [ADR Template](../adrs/template.md)
+- [ADR Documentation](./adrs.md)
 - [Canon Philosophy](../axioms.md)


### PR DESCRIPTION
Fix broken document-to-document links to ensure they work correctly when published via GitHub Pages.

Many links were broken due to incorrect relative paths, references to non-existent files, and issues with the VitePress base URL (`/canon/`). This PR updates file paths, removes references to non-existent documents, and corrects sidebar navigation in the VitePress configuration.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ff4b2e6-d0b0-4dc0-b5e6-de402280a24f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4ff4b2e6-d0b0-4dc0-b5e6-de402280a24f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

