### PR TITLE
Automate adr index generation on push

### DIFF
--- a/.github/workflows/update-adr-index.yml
+++ b/.github/workflows/update-adr-index.yml
@@ -1,0 +1,53 @@
+name: Update ADR Index
+
+on:
+  push:
+    paths:
+      - 'docs/adrs/*.md'
+      - '!docs/adrs/README.md'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update-adr-index:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate ADR Index
+        run: node scripts/generate-adr-index.js
+
+      - name: Check for changes
+        id: verify-changed-files
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit and push changes
+        if: steps.verify-changed-files.outputs.changed == 'true'
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add docs/adrs/README.md
+          git commit -m "docs: auto-update ADR index table
+
+          - Updated ADR index with current status and dates
+          - Generated automatically from ADR files"
+          git push

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -8,16 +8,18 @@ Architecture Decision Records are documents that capture important architectural
 
 ## ADR List
 
-- [ADR-0001: TypeScript Package Setup](./0001-typescript-package-setup)
-- [ADR-0002: ESLint Configuration with Antfu](./0002-eslint-configuration-with-antfu)
-- [ADR-0003: Documentation Linting Inclusion](./0003-documentation-linting-inclusion)
-- [ADR-0004: TypeScript Configuration Separation](./0004-typescript-configuration-separation)
-- [ADR-0005: ESLint Configuration Abstraction](./0005-eslint-configuration-abstraction)
-- [ADR-0006: Unbuilt TypeScript Library](./0006-unbuilt-typescript-library)
-- [ADR-0007: Y-Statement Format](./0007-y-statement-format)
-- [ADR-0008: Dual Export Strategy](./0008-dual-export-strategy)
-- [ADR-0009: Node.js Version Requirement](./0009-node-js-version-requirement)
-- [ADR-0010: VitePress Documentation Solution](./0010-vitepress-documentation-solution)
+| ADR | Title | Status | Date |
+|-----|-------|--------|------|
+| [ADR-001](./0001-typescript-package-setup) | TypeScript Package Setup | 🟢 Accepted | 2025-01-26 |
+| [ADR-002](./0002-eslint-configuration-with-antfu) | ESLint Configuration with Antfu | 🟢 Accepted | 2025-01-26 |
+| [ADR-003](./0003-documentation-linting-inclusion) | Documentation Linting Inclusion | 🟢 Accepted | 2025-01-26 |
+| [ADR-004](./0004-typescript-configuration-separation) | TypeScript Configuration Separation | 🟢 Accepted | 2025-01-26 |
+| [ADR-005](./0005-eslint-configuration-abstraction) | ESLint Configuration Abstraction | 🟢 Accepted | 2025-01-26 |
+| [ADR-006](./0006-unbuilt-typescript-library) | Unbuilt TypeScript Library | 🟢 Accepted | 2025-01-26 |
+| [ADR-007](./0007-y-statement-format) | Y-Statement Format for ADRs | 🟢 Accepted | 2025-01-26 |
+| [ADR-008](./0008-dual-export-strategy) | Dual Export Strategy | 🟢 Accepted | 2025-01-26 |
+| [ADR-009](./0009-node-js-version-requirement) | Node.js Version Requirement | 🟢 Accepted | 2025-01-26 |
+| [ADR-0010](./0010-vitepress-documentation-solution) | VitePress Documentation Solution | 🟢 Accepted | 2025-01-26 |
 
 ## ADR Process
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "adr:new": "cd docs/adrs && npx adr new",
     "adr:list": "cd docs/adrs && npx adr list",
     "adr:index": "cd docs/adrs && npx adr generate toc",
+    "adr:generate-index": "node scripts/generate-adr-index.js",
     "radar:convert": "tsx scripts/convert-radar.ts",
     "radar:validate": "tsx scripts/validate-radar.ts",
     "radar:watch": "chokidar './docs/planning/radar/data.yaml' -c 'npm run radar:convert'",

--- a/scripts/generate-adr-index.js
+++ b/scripts/generate-adr-index.js
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync, readdirSync, statSync } from 'fs'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+// Paths
+const adrsDir = join(__dirname, '..', 'docs', 'adrs')
+const readmePath = join(adrsDir, 'README.md')
+
+// Status color mapping
+const statusColors = {
+  'proposed': '🟡',
+  'accepted': '🟢', 
+  'deprecated': '🔴',
+  'superseded': '🟠'
+}
+
+// Status labels
+const statusLabels = {
+  'proposed': 'Proposed',
+  'accepted': 'Accepted',
+  'deprecated': 'Deprecated', 
+  'superseded': 'Superseded'
+}
+
+function extractAdrInfo(filePath) {
+  try {
+    const content = readFileSync(filePath, 'utf-8')
+    const lines = content.split('\n')
+    
+    // Extract title (first line after #)
+    const titleLine = lines.find(line => line.startsWith('# ADR-'))
+    if (!titleLine) return null
+    
+    const title = titleLine.replace('# ADR-', '').trim()
+    
+    // Extract status (line with "* Status:")
+    const statusLine = lines.find(line => line.includes('* Status:'))
+    if (!statusLine) return null
+    
+    const status = statusLine.split('* Status:')[1]?.trim().toLowerCase()
+    if (!status || !statusColors[status]) return null
+    
+    // Extract date (line with "* Date:")
+    const dateLine = lines.find(line => line.includes('* Date:'))
+    const date = dateLine ? dateLine.split('* Date:')[1]?.trim() : 'Unknown'
+    
+    // Extract filename without extension for link
+    const filename = filePath.split('/').pop().replace('.md', '')
+    
+    return {
+      number: title.split(':')[0],
+      title: title.split(':').slice(1).join(':').trim(),
+      status,
+      date,
+      filename,
+      color: statusColors[status],
+      label: statusLabels[status]
+    }
+  } catch (error) {
+    console.error(`Error reading ${filePath}:`, error.message)
+    return null
+  }
+}
+
+function generateAdrTable(adrs) {
+  // Sort by ADR number
+  adrs.sort((a, b) => parseInt(a.number) - parseInt(b.number))
+  
+  const tableHeader = `| ADR | Title | Status | Date |\n|-----|-------|--------|------|`
+  
+  const tableRows = adrs.map(adr => 
+    `| [ADR-${adr.number}](./${adr.filename}) | ${adr.title} | ${adr.color} ${adr.label} | ${adr.date} |`
+  ).join('\n')
+  
+  return `${tableHeader}\n${tableRows}`
+}
+
+function updateReadme(adrTable) {
+  try {
+    const readmeContent = readFileSync(readmePath, 'utf-8')
+    
+    // Find the ADR List section and replace it with the table
+    const adrListStart = readmeContent.indexOf('## ADR List')
+    const adrProcessStart = readmeContent.indexOf('## ADR Process')
+    
+    if (adrListStart === -1 || adrProcessStart === -1) {
+      throw new Error('Could not find ADR List section in README')
+    }
+    
+    const beforeAdrList = readmeContent.substring(0, adrListStart)
+    const afterAdrProcess = readmeContent.substring(adrProcessStart)
+    
+    const newContent = `${beforeAdrList}## ADR List
+
+${adrTable}
+
+${afterAdrProcess}`
+    
+    writeFileSync(readmePath, newContent, 'utf-8')
+    console.log('✅ ADR index updated successfully')
+    
+  } catch (error) {
+    console.error('Error updating README:', error.message)
+    process.exit(1)
+  }
+}
+
+function main() {
+  console.log('🔍 Scanning ADR files...')
+  
+  try {
+    const files = readdirSync(adrsDir)
+      .filter(file => file.endsWith('.md') && file !== 'README.md')
+      .map(file => join(adrsDir, file))
+      .filter(file => statSync(file).isFile())
+    
+    console.log(`📁 Found ${files.length} ADR files`)
+    
+    const adrs = files
+      .map(extractAdrInfo)
+      .filter(adr => adr !== null)
+    
+    console.log(`✅ Successfully parsed ${adrs.length} ADRs`)
+    
+    if (adrs.length === 0) {
+      console.log('⚠️  No valid ADRs found')
+      return
+    }
+    
+    const adrTable = generateAdrTable(adrs)
+    updateReadme(adrTable)
+    
+    // Log summary
+    const statusCounts = adrs.reduce((acc, adr) => {
+      acc[adr.status] = (acc[adr.status] || 0) + 1
+      return acc
+    }, {})
+    
+    console.log('\n📊 ADR Status Summary:')
+    Object.entries(statusCounts).forEach(([status, count]) => {
+      console.log(`  ${statusColors[status]} ${statusLabels[status]}: ${count}`)
+    })
+    
+  } catch (error) {
+    console.error('Error:', error.message)
+    process.exit(1)
+  }
+}
+
+main()


### PR DESCRIPTION
Automate the generation and maintenance of the ADR index in `docs/adrs/README.md` to ensure it is always up-to-date, includes status, and eliminates manual updates.

---
<a href="https://cursor.com/background-agent?bcId=bc-76c4e47f-1e51-4ce4-8f3f-dc41ffb87d2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-76c4e47f-1e51-4ce4-8f3f-dc41ffb87d2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

