### PR TITLE
Update documentation links and structure

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -11,9 +11,9 @@ export default {
     // Navigation bar
     nav: [
       { text: 'Home', link: '/' },
-      { text: 'Documentation', link: '/docs/README' },
-      { text: 'ADRs', link: '/adrs/README' },
-      { text: 'Planning', link: '/planning/README' }
+      { text: 'ADRs', link: '/adrs/' },
+      { text: 'Examples', link: '/docs/examples/' },
+      { text: 'Planning', link: '/planning/' }
     ],
     
     // Sidebar configuration
@@ -23,7 +23,7 @@ export default {
         {
           text: 'Documentation',
           items: [
-            { text: 'Introduction', link: '/docs/README' },
+            { text: 'Introduction', link: '/docs/' },
             { text: 'Canons', link: '/docs/canons' },
             { text: 'Axioms', link: '/docs/axioms' },
             {
@@ -44,7 +44,7 @@ export default {
         {
           text: 'Architecture Decision Records',
           items: [
-            { text: 'About ADRs', link: '/adrs/README' },
+            { text: 'About ADRs', link: '/adrs/' },
             { text: '1. TypeScript Package Setup', link: '/adrs/0001-typescript-package-setup' },
             { text: '2. ESLint Configuration with Antfu', link: '/adrs/0002-eslint-configuration-with-antfu' },
             { text: '3. Documentation Linting Inclusion', link: '/adrs/0003-documentation-linting-inclusion' },
@@ -55,6 +55,19 @@ export default {
             { text: '8. Dual Export Strategy', link: '/adrs/0008-dual-export-strategy' },
             { text: '9. Node.js Version Requirement', link: '/adrs/0009-node-js-version-requirement' },
             { text: '10. VitePress Documentation Solution', link: '/adrs/0010-vitepress-documentation-solution' }
+          ]
+        }
+      ],
+      
+      // Examples sidebar
+      '/docs/examples/': [
+        {
+          text: 'Examples',
+          items: [
+            { text: 'Overview', link: '/docs/examples/' },
+            { text: 'Deduplicating Entities', link: '/docs/examples/deduplicating-entities' },
+            { text: 'Tree Walk Over Mixed Entities', link: '/docs/examples/tree-walk-over-mixed-entities' },
+            { text: 'User Authentication Tokens', link: '/docs/examples/user-authentication-tokens' }
           ]
         }
       ],

--- a/scripts/rename-readmes-for-build.sh
+++ b/scripts/rename-readmes-for-build.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 # Rename README.md files to index.md for VitePress build
-# Skip the main docs directory to avoid conflicts
+# Renames ALL README.md files in docs directory
 
 echo "Starting README.md → index.md rename for VitePress build..."
 
-# Find and rename README.md files in subdirectories only
-find docs -name "README.md" -not -path "docs/README.md" | while read file; do
+# Find and rename ALL README.md files in docs directory
+find docs -name "README.md" | while read file; do
     dir=$(dirname "$file")
     echo "Renamed: $file → $dir/index.md"
     mv "$file" "$dir/index.md"

--- a/scripts/restore-readmes-from-build.sh
+++ b/scripts/restore-readmes-from-build.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 # Restore index.md files back to README.md after VitePress build
-# Skip .vitepress directory and main docs directory
+# Restores ALL index.md files in docs directory except .vitepress
 
 echo "Starting index.md → README.md restore after VitePress build..."
 
-# Find and restore index.md files, excluding .vitepress and main docs
-find docs -name "index.md" -not -path "docs/.vitepress/*" -not -path "docs/index.md" | while read file; do
+# Find and restore index.md files, excluding .vitepress directory
+find docs -name "index.md" -not -path "docs/.vitepress/*" | while read file; do
     dir=$(dirname "$file")
     echo "Restored: $file → $dir/README.md"
     mv "$file" "$dir/README.md"


### PR DESCRIPTION
Update documentation build scripts to rename all `README.md` files to `index.md` and refine VitePress navigation for clarity and completeness.

The original build script was not renaming the top-level `docs/README.md`, causing inconsistencies. The navigation was also redundant and incomplete, with incorrect paths and missing links for key sections like 'Examples'. This PR fixes these issues to ensure a consistent and navigable documentation site.

---
<a href="https://cursor.com/background-agent?bcId=bc-a372f557-7586-46b2-91e5-de08c75f8bad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a372f557-7586-46b2-91e5-de08c75f8bad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

