### PR TITLE
Check internal markdown links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,10 +29,10 @@ export default createEslintConfig()
 
 ## Documentation Sections
 
-- **[Canons](/docs/canons)** - Core principles and guidelines
-- **[Axioms](/docs/axioms)** - Fundamental assumptions and rules
-- **[Examples](/docs/examples/)** - Practical usage examples
-- **[Radar Methodology](/docs/radar-methodology)** - Technology assessment approach
+- **[Canons](/canons)** - Core principles and guidelines
+- **[Axioms](/axioms)** - Fundamental assumptions and rules
+- **[Examples](/examples/)** - Practical usage examples
+- **[Radar Methodology](/radar-methodology)** - Technology assessment approach
 
 ## Architecture Decisions
 

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -27,4 +27,4 @@ This information is intended for:
 
 ## Contributing
 
-See the main [Contributing Guidelines](../CONTRIBUTING.md) for how to contribute to Canon, including strategic planning and roadmap discussions.
+See the main [Contributing Guidelines](../../CONTRIBUTING.md) for how to contribute to Canon, including strategic planning and roadmap discussions.

--- a/docs/planning/radar/README.md
+++ b/docs/planning/radar/README.md
@@ -24,7 +24,7 @@ The radar functionality is now part of the main Canon package. You can use it pr
 import { convertYamlFileToCsv, validateRadarFile } from '@relational-fabric/canon'
 
 // Convert YAML to CSV (outputs to docs/public/radar/)
-convertYamlFileToCsv('./data.yaml', './docs/public/radar/data.csv')
+convertYamlFileToCsv('./data.yaml', '../../public/radar/data.csv')
 
 // Validate radar data
 const result = await validateRadarFile('./data.yaml')

--- a/docs/planning/radar/README.md
+++ b/docs/planning/radar/README.md
@@ -24,10 +24,10 @@ The radar functionality is now part of the main Canon package. You can use it pr
 import { convertYamlFileToCsv, validateRadarFile } from '@relational-fabric/canon'
 
 // Convert YAML to CSV (outputs to docs/public/radar/)
-convertYamlFileToCsv('./docs/planning/radar/data.yaml', './docs/public/radar/data.csv')
+convertYamlFileToCsv('./data.yaml', './docs/public/radar/data.csv')
 
 // Validate radar data
-const result = await validateRadarFile('./docs/planning/radar/data.yaml')
+const result = await validateRadarFile('./data.yaml')
 if (!result.isValid) {
   console.error('Validation errors:', result.errors)
 }

--- a/docs/radar-methodology.md
+++ b/docs/radar-methodology.md
@@ -206,4 +206,4 @@ Each major radar decision should be documented as an ADR, including:
 - [ThoughtWorks Technology Radar](https://www.thoughtworks.com/radar)
 - [Build Your Own Radar](https://github.com/thoughtworks/build-your-own-radar)
 - [ADR Documentation](./adrs.md)
-- [Canon Philosophy](../axioms.md)
+- [Canon Philosophy](./axioms.md)


### PR DESCRIPTION
Correct relative paths in `docs/planning/radar/README.md` to properly reference files within the same directory.

The previous paths like `./docs/planning/radar/data.yaml` were incorrect because the `README.md` file is already located in `docs/planning/radar/`, making the `docs/planning/radar/` prefix redundant and causing incorrect resolution for relative paths. The fix changes these to `./data.yaml` for correct relative referencing.

---
<a href="https://cursor.com/background-agent?bcId=bc-d1f0f199-48e0-401a-9a65-9d37d44bfcfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d1f0f199-48e0-401a-9a65-9d37d44bfcfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

